### PR TITLE
Worked around an issue with unescaped string literals in Django JavaScript i18n code

### DIFF
--- a/statici18n/management/commands/compilejsi18n.py
+++ b/statici18n/management/commands/compilejsi18n.py
@@ -14,6 +14,8 @@ from django.views.i18n import (LibHead, LibFoot, LibFormatHead, LibFormatFoot,
 from statici18n.conf import settings
 from statici18n.utils import get_filename
 
+LibFoot = LibFoot.replace('\x04', '\\x04')
+
 
 # This function is a ripoff of `django.views.i18n.javascript_catalog with
 # all the request specific code removed.


### PR DESCRIPTION
This is rather annoying, but really not possible to easily fix it in 1.4 releases.
