### PR TITLE
Updated for appconf release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django-appconf==0.6
+django-appconf>=0.6
 six==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "Django>=1.4",
-        "django-appconf>=0.4",
+        "django-appconf>=0.6",
     ],
     license="BSD",
     classifiers=[


### PR DESCRIPTION
I changed the requirements to allow for django-appconf to consume the latest release but remain backwards compatible.  Also noticed that setup.py was showing that the install requirements was different than the requirements.txt, so bumped setup.py to reflect.