### PR TITLE
Fix unhashed paths with ManifestFilesStorage

### DIFF
--- a/src/statici18n/conf.py
+++ b/src/statici18n/conf.py
@@ -8,8 +8,6 @@ class StaticFilesConf(AppConf):
     DOMAIN = 'djangojs'
     # A list of packages to check for translations.
     PACKAGES = ('django.conf')
-    # Controls the file path that generated catalog will be written into.
-    ROOT = settings.STATIC_ROOT
     # Controls the directory inside STATICI18N_ROOT
     # that generated files will be written to.
     OUTPUT_DIR = 'jsi18n'

--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -16,7 +16,7 @@ except ImportError:
     from staticfiles.storage import staticfiles_storage
 
 from statici18n.conf import settings
-from statici18n.utils import get_path
+from statici18n.utils import get_filename, get_path
 
 import django
 if django.VERSION >= (1, 6):
@@ -97,7 +97,6 @@ class Command(NoArgsCommand):
                     if processed:
                         self.stdout.write("Post-processed file %s as %s" %
                                          (original_path, processed_path))
-
 
         for locale in languages:
             if verbosity > 0:

--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -16,7 +16,7 @@ except ImportError:
     from staticfiles.storage import staticfiles_storage
 
 from statici18n.conf import settings
-from statici18n.utils import get_filename
+from statici18n.utils import get_path
 
 import django
 if django.VERSION >= (1, 6):
@@ -83,7 +83,7 @@ class Command(NoArgsCommand):
             paths = OrderedDict()
 
             def write_file(locale, content):
-                path = get_filename(locale, domain)
+                path = get_path(locale, domain)
                 paths[path] = (staticfiles_storage, path)
                 staticfiles_storage.save(path,
                                          StringIO(content))

--- a/src/statici18n/templatetags/statici18n.py
+++ b/src/statici18n/templatetags/statici18n.py
@@ -8,7 +8,6 @@ except ImportError:
     from staticfiles.templatetags.staticfiles import static
     from staticfiles.storage import staticfiles_storage
 
-from statici18n.conf import settings
 from statici18n.utils import get_path
 
 register = template.Library()

--- a/src/statici18n/templatetags/statici18n.py
+++ b/src/statici18n/templatetags/statici18n.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import os
 from django import template
 
 try:

--- a/src/statici18n/templatetags/statici18n.py
+++ b/src/statici18n/templatetags/statici18n.py
@@ -10,14 +10,9 @@ except ImportError:
     from staticfiles.storage import staticfiles_storage
 
 from statici18n.conf import settings
-from statici18n.utils import get_filename
+from statici18n.utils import get_path
 
 register = template.Library()
-
-
-def get_path(locale):
-    return os.path.join(settings.STATICI18N_OUTPUT_DIR,
-                        get_filename(locale, settings.STATICI18N_DOMAIN))
 
 
 @register.simple_tag

--- a/src/statici18n/utils.py
+++ b/src/statici18n/utils.py
@@ -36,6 +36,7 @@ def default_filename(locale, domain):
     from django.utils.translation.trans_real import to_language
     return os.path.join(to_language(locale), '%s.js' % domain)
 
+
 def get_path(locale, domain=None):
     if domain is None:
         domain = settings.STATICI18N_DOMAIN

--- a/src/statici18n/utils.py
+++ b/src/statici18n/utils.py
@@ -35,3 +35,7 @@ def get_filename(*args, **kwargs):
 def default_filename(locale, domain):
     from django.utils.translation.trans_real import to_language
     return os.path.join(to_language(locale), '%s.js' % domain)
+
+def get_path(locale):
+    return os.path.join(settings.STATICI18N_OUTPUT_DIR,
+                        get_filename(locale, settings.STATICI18N_DOMAIN))

--- a/src/statici18n/utils.py
+++ b/src/statici18n/utils.py
@@ -36,6 +36,9 @@ def default_filename(locale, domain):
     from django.utils.translation.trans_real import to_language
     return os.path.join(to_language(locale), '%s.js' % domain)
 
-def get_path(locale):
+def get_path(locale, domain=None):
+    if domain is None:
+        domain = settings.STATICI18N_DOMAIN
+
     return os.path.join(settings.STATICI18N_OUTPUT_DIR,
-                        get_filename(locale, settings.STATICI18N_DOMAIN))
+                        get_filename(locale, domain))


### PR DESCRIPTION
These series of commits uses the Django `staticfiles` storage backend to save the files, and calls the `post_process` method of the storage to properly mimic `collectstatic`. `HashedFilesMixin.post_process`  is what handles the hashing.