### PR TITLE
Mark inlinei18n output as safe

### DIFF
--- a/src/statici18n/templatetags/statici18n.py
+++ b/src/statici18n/templatetags/statici18n.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import os
 from django import template
+from django.utils.safestring import mark_safe
 
 try:
     from django.contrib.staticfiles.templatetags.staticfiles import static
@@ -41,4 +42,4 @@ def inlinei18n(locale):
     Behind the scenes, this is a thin wrapper around staticfiles's configred
     storage
     """
-    return staticfiles_storage.open(get_path(locale)).read()
+    return mark_safe(staticfiles_storage.open(get_path(locale)).read())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -80,7 +80,7 @@ def test_statici18n_templatetag():
 def test_inlinei18n_templatetag():
     template = """
     {% load statici18n %}
-    <script src="{% inlinei18n LANGUAGE_CODE %}"></script>
+    <script>{% inlinei18n LANGUAGE_CODE %}</script>
     """
     management.call_command('compilejsi18n')
     template = get_template_from_string(template)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -86,3 +86,4 @@ def test_inlinei18n_templatetag():
     template = get_template_from_string(template)
     rendered = template.render(Context({'LANGUAGE_CODE': 'fr'})).strip()
     assert 'var django = globals.django || (globals.django = {});' in rendered
+    assert '&quot;' not in rendered


### PR DESCRIPTION
Otherwise `django` will try to escape the JavaScript output, corrupting it in the process.