### PR TITLE
Add support for `USE_I18N = False`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v.next (unreleased)
+-------------------
+
+* Added support for `USE_18N = False` (#19).
+
 v1.1.5 (2015 Aug 7)
 -------------------
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -13,7 +13,8 @@ Collect JavaScript catalog files in a single location.
 Some commonly used options are:
 
 ``-l LOCALE`` or ``--locale=LOCALE``
-    The locale to process. Default is to process all.
+    The locale to process. Default is to process all but if for some reason I18N
+    features are disabled, only `settings.LANGUAGE_CODE` will be processed.
 
 ``-d DOMAIN`` or ``--domain=DOMAIN``
     Override the gettext domain. By default, the command uses the ``djangojs``

--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -25,7 +25,9 @@ else:
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
         make_option('--locale', '-l', dest='locale',
-                    help="The locale to process. Default is to process all."),
+                    help="The locale to process. Default is to process all "
+                         "but if for some reason I18N features are disabled, "
+                         "only `settings.LANGUAGE_CODE` will be processed."),
         make_option('-d', '--domain',
                     dest='domain', default=settings.STATICI18N_DOMAIN,
                     help="Override the gettext domain. By default, "
@@ -55,6 +57,8 @@ class Command(NoArgsCommand):
 
         if locale is not None:
             languages = [locale]
+        elif not settings.USE_I18N:
+            languages = [settings.LANGUAGE_CODE]
         else:
             languages = [to_locale(lang_code)
                          for (lang_code, lang_name) in settings.LANGUAGES]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -40,6 +40,26 @@ def test_compile_all(settings):
         assert '"Hello world!": "Bonjour \\u00e0 tous !"' in content
 
 
+@pytest.mark.parametrize('locale', ['en-us', 'en', 'de'])
+def test_compile_no_use_i18n(settings, locale):
+    """Tests compilation when `USE_I18N = False`.
+
+    In this scenario, only the `settings.LANGUAGE_CODE` locale is processed
+    (it defaults to `en-us` for Django projects).
+    """
+    settings.USE_I18N = False
+    settings.LANGUAGE_CODE = locale
+
+    out = six.StringIO()
+    management.call_command('compilejsi18n', verbosity=1, stdout=out)
+    out.seek(0)
+    lines = [l.strip() for l in out.readlines()]
+    assert len(lines) == 1
+    assert lines[0] == "processing language %s" % locale
+    assert os.path.exists(os.path.join(
+        settings.STATIC_ROOT, "jsi18n", locale, "djangojs.js"))
+
+
 @pytest.mark.usefixtures("cleandir")
 def test_compile_locale_not_exists():
     out = six.StringIO()


### PR DESCRIPTION
In this scenario, only `settings.LANGUAGE_CODE` will be processed (defaults to
'en-us' in Django projects).

Note that `{% get_current_languagage as LANGUAGE_CODE %}` returns
`settings.LANGUAGE_CODE` when I18N features are off, so this patch allows
template code such as ``{% statici18n LANGUAGE_CODE %}` to work seamlessly under
these circumstances.

Fixes #19.