### PR TITLE
Add support for JSON catalog

### DIFF
--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 
 import io
 import os
+import json
 from optparse import make_option
 
 from django.core.management.base import NoArgsCommand
@@ -15,11 +16,13 @@ import django
 if django.VERSION >= (1, 6):
     # Django >= 1.6
     from django.views.i18n import (get_javascript_catalog,
-                                   render_javascript_catalog)
+                                   render_javascript_catalog,
+                                   get_formats)
 else:
     # Django <= 1.5
     from statici18n.compat import (get_javascript_catalog,
-                                   render_javascript_catalog)
+                                   render_javascript_catalog,
+                                   get_formats)
 
 
 class Command(NoArgsCommand):
@@ -39,7 +42,11 @@ class Command(NoArgsCommand):
                          "add more."),
         make_option('-o', '--output', dest='outputdir', metavar='OUTPUT_DIR',
                     help="Output directory to store generated catalogs. "
-                         "Defaults to static/jsi18n.")
+                         "Defaults to static/jsi18n."),
+        make_option('-f', '--format', dest='outputformat', metavar='OUTPUT_FORMAT',
+                    choices=['js', 'json'], default='js',
+                    help="Format of the output catalog. Options are: js, json "
+                         "Defaults to js."),
     )
     help = "Collect Javascript catalog files in a single location."
 
@@ -48,11 +55,46 @@ class Command(NoArgsCommand):
         if hasattr(self, 'requires_system_checks'):
             self.requires_system_checks = False
 
+    def _create_javascript_catalog(self, locale, domain, packages):
+        activate(locale)
+        catalog, plural = get_javascript_catalog(locale, domain, packages)
+        response = render_javascript_catalog(catalog, plural)
+
+        return force_text(response.content)
+
+    def _create_json_catalog(self, locale, domain, packages):
+        activate(locale)
+        catalog, plural = get_javascript_catalog(locale, domain, packages)
+        data = {
+            'catalog': catalog,
+            'formats': get_formats(),
+            'plural': plural,
+        }
+
+        return force_text(json.dumps(data, ensure_ascii=False))
+
+    def _create_output(self, outputdir, outputformat, locale, domain, packages):
+        outputfile = os.path.join(outputdir, get_filename(locale, domain, outputformat))
+        basedir = os.path.dirname(outputfile)
+        if not os.path.isdir(basedir):
+            os.makedirs(basedir)
+
+        if outputformat == 'js':
+            data = self._create_javascript_catalog(locale, domain, packages)
+        elif outputformat == 'json':
+            data = self._create_json_catalog(locale, domain, packages)
+        else:
+            raise NotImplementedError("Unknown format %s" % (outputformat))
+
+        with io.open(outputfile, "w", encoding="utf-8") as fp:
+            fp.write(data)
+
     def handle_noargs(self, **options):
         locale = options.get('locale')
         domain = options['domain']
         packages = options['packages'] or settings.STATICI18N_PACKAGES
         outputdir = options['outputdir']
+        outputformat = options['outputformat']
         verbosity = int(options.get('verbosity'))
 
         if locale is not None:
@@ -71,14 +113,4 @@ class Command(NoArgsCommand):
             if verbosity > 0:
                 self.stdout.write("processing language %s\n" % locale)
 
-            jsfile = os.path.join(outputdir, get_filename(locale, domain))
-            basedir = os.path.dirname(jsfile)
-            if not os.path.isdir(basedir):
-                os.makedirs(basedir)
-
-            activate(locale)
-            catalog, plural = get_javascript_catalog(locale, domain, packages)
-            response = render_javascript_catalog(catalog, plural)
-
-            with io.open(jsfile, "w", encoding="utf-8") as fp:
-                fp.write(force_text(response.content))
+            self._create_output(outputdir, outputformat, locale, domain, packages)

--- a/src/statici18n/utils.py
+++ b/src/statici18n/utils.py
@@ -32,6 +32,6 @@ def get_filename(*args, **kwargs):
     return _filename_func(*args, **kwargs)
 
 
-def default_filename(locale, domain):
+def default_filename(locale, domain, outputformat):
     from django.utils.translation.trans_real import to_language
-    return os.path.join(to_language(locale), '%s.js' % domain)
+    return os.path.join(to_language(locale), '%s.%s' % (domain, outputformat))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,16 +4,27 @@ from statici18n import utils
 
 
 def test_default_filename_with_language():
-    filename = utils.get_filename('en', 'djangojs')
+    filename = utils.get_filename('en', 'djangojs', 'js')
     assert filename == 'en/djangojs.js'
 
-    filename = utils.get_filename('en-us', 'djangojs')
+    filename = utils.get_filename('en-us', 'djangojs', 'js')
     assert filename == 'en-us/djangojs.js'
 
 
 def test_default_filename_with_locale():
-    filename = utils.get_filename('en_GB', 'djangojs')
+    filename = utils.get_filename('en_GB', 'djangojs', 'js')
     assert filename == 'en-gb/djangojs.js'
+
+
+def test_default_filename_with_outputformat():
+    filename = utils.get_filename('en', 'djangojs', 'js')
+    assert filename == 'en/djangojs.js'
+
+    filename = utils.get_filename('en', 'djangojs', 'json')
+    assert filename == 'en/djangojs.json'
+
+    filename = utils.get_filename('en', 'djangojs', 'yaml')
+    assert filename == 'en/djangojs.yaml'
 
 
 def custom_func(locale, domain):


### PR DESCRIPTION
This PR adds new functionality for generating JS catalogs in json format, the same way as django does in their [json_catalog view](https://docs.djangoproject.com/es/1.10/topics/i18n/translation/#the-json-catalog-view).

The usage is as follows: `python manage.py compilejsi18n --format json` (its default value is `js`, so the behaviour is the same as before).