### PR TITLE
Adding Django 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
   - DJANGO_VERSION=1.10
+  - DJANGO_VERSION=1.11
 matrix:
   exclude:
     - python: "3.2"
@@ -19,6 +20,10 @@ matrix:
       env: DJANGO_VERSION=1.10
     - python: "3.3"
       env: DJANGO_VERSION=1.10
+    - python: "3.3"
+      env: DJANGO_VERSION=1.11
+    - python: "3.2"
+      env: DJANGO_VERSION=1.11
 before_install:
   - sudo apt-get install -y shtool
   - shtool version -s "${DJANGO_VERSION}.0" dj_version.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - shtool version -i r dj_version.txt
   # Required to support Python 3.2, should be able to be removed
   # when support for Django 1.8 / Python 3.2 is dropped.
-  - pip install pip<8 setuptools<30 virtualenv<14
+  - pip install "pip<8" "setuptools<30" "virtualenv<14"
 install:
   - NEW_DJANGO_VERSION=$(shtool version -d short dj_version.txt)
   - pip install -q "Django>=${DJANGO_VERSION},<${NEW_DJANGO_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_install:
   - sudo apt-get install -y shtool
   - shtool version -s "${DJANGO_VERSION}.0" dj_version.txt
   - shtool version -i r dj_version.txt
+  # Required to support Python 3.2, should be able to be removed
+  # when support for Django 1.8 / Python 3.2 is dropped.
+  - pip install pip<8 setuptools<30 virtualenv<14
 install:
   - NEW_DJANGO_VERSION=$(shtool version -d short dj_version.txt)
   - pip install -q "Django>=${DJANGO_VERSION},<${NEW_DJANGO_VERSION}"

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Supported Django Versions
 -------------------------
 
 django-statici18n works with all the Django versions officially supported by the
-Django project. At the time of writing, these are the 1.8 (LTS), 1.9 and 1.10
+Django project. At the time of writing, these are the 1.8 (LTS), 1.9, 1.10, and 1.11 (LTS)
 series.
 
 Installation

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ envlist =
     py27-django110,
     py34-django110,
     py35-django110,
+    py27-django111,
+    py34-django111,
+    py35-django111,
     flake8,
     coverage
 
@@ -111,6 +114,36 @@ deps =
 basepython = python3.5
 deps =
     Django>=1.10,<1.11
+    {[testenv]deps}
+
+[testenv:py27-django111]
+basepython = python2.7
+deps =
+    Django>=1.11,<2
+    {[testenv]deps}
+
+[testenv:py32-django111]
+basepython = python3.2
+deps =
+    Django>=1.11,<2
+    {[testenv]deps}
+
+[testenv:py33-django111]
+basepython = python3.3
+deps =
+    Django>=1.11,<2
+    {[testenv]deps}
+
+[testenv:py34-django111]
+basepython = python3.4
+deps =
+    Django>=1.11,<2
+    {[testenv]deps}
+
+[testenv:py35-django111]
+basepython = python3.5
+deps =
+    Django>=1.11,<2
     {[testenv]deps}
 
 ; [testenv:docs]


### PR DESCRIPTION
Adding support for Django 1.11 to tests, docs, and CI

- No additional code changes were necessary to make tox tests work locally
- I was only able to run tests against Python 2.7 and 3.5 locally