### PR TITLE
Load statici18n conf via Django's `AppConfig`

### DIFF
--- a/src/statici18n/__init__.py
+++ b/src/statici18n/__init__.py
@@ -1,2 +1,4 @@
 # following PEP 386
 __version__ = "1.4.0"
+
+default_app_config = 'statici18n.apps.StaticI18NConfig'

--- a/src/statici18n/apps.py
+++ b/src/statici18n/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class StaticI18NConfig(AppConfig):
+    name = 'statici18n'
+
+    def ready(self):
+        from . import conf

--- a/src/statici18n/apps.py
+++ b/src/statici18n/apps.py
@@ -5,4 +5,4 @@ class StaticI18NConfig(AppConfig):
     name = 'statici18n'
 
     def ready(self):
-        from . import conf
+        from . import conf  # noqa


### PR DESCRIPTION
This is required to be able to use anything that uses django-statici18n
in tests that use Django's `override_settings` helper.

Refs. https://github.com/django-compressor/django-appconf/issues/30