### PR TITLE
Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - DJANGO_VERSION=1.9.13
   - DJANGO_VERSION=1.10.8
   - DJANGO_VERSION=1.11.8
-  - DJANGO_VERSION=2.0.1
+  - DJANGO_VERSION=2.0
 matrix:
   exclude:
     - python: "3.2"
@@ -26,9 +26,9 @@ matrix:
     - python: "3.2"
       env: DJANGO_VERSION=1.11.8
     - python: "3.3"
-      env: DJANGO_VERSION=2.0.1
+      env: DJANGO_VERSION=2.0
     - python: "3.2"
-      env: DJANGO_VERSION=2.0.1
+      env: DJANGO_VERSION=2.0
 before_install:
   # Downgrade virtualenv version due to Python 3.2 drop support
   # in virtualenv >= 14.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DJANGO_VERSION=1.9.13
   - DJANGO_VERSION=1.10.8
   - DJANGO_VERSION=1.11.8
+  - DJANGO_VERSION=2.0.1
 matrix:
   exclude:
     - python: "3.2"
@@ -24,6 +25,10 @@ matrix:
       env: DJANGO_VERSION=1.11.8
     - python: "3.2"
       env: DJANGO_VERSION=1.11.8
+    - python: "3.3"
+      env: DJANGO_VERSION=2.0.1
+    - python: "3.2"
+      env: DJANGO_VERSION=2.0.1
 before_install:
   # Downgrade virtualenv version due to Python 3.2 drop support
   # in virtualenv >= 14.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       env: DJANGO_VERSION=1.10.8
     - python: "3.3"
       env: DJANGO_VERSION=1.11.8
+    - python: "2.7"
+      env: DJANGO_VERSION=2.0
     - python: "3.3"
       env: DJANGO_VERSION=2.0
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -13,26 +12,14 @@ env:
   - DJANGO_VERSION=2.0
 matrix:
   exclude:
-    - python: "3.2"
-      env: DJANGO_VERSION=1.9.13
     - python: "3.3"
       env: DJANGO_VERSION=1.9.13
-    - python: "3.2"
-      env: DJANGO_VERSION=1.10.8
     - python: "3.3"
       env: DJANGO_VERSION=1.10.8
     - python: "3.3"
       env: DJANGO_VERSION=1.11.8
-    - python: "3.2"
-      env: DJANGO_VERSION=1.11.8
     - python: "3.3"
       env: DJANGO_VERSION=2.0
-    - python: "3.2"
-      env: DJANGO_VERSION=2.0
-before_install:
-  # Downgrade virtualenv version due to Python 3.2 drop support
-  # in virtualenv >= 14.0.0
-  - pip install --upgrade virtualenv==13.1.2
 install:
   - pip install -q Django==$DJANGO_VERSION
   - pip install -q -r requirements-test.txt

--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -57,6 +57,8 @@ class Command(BaseCommand):
             response = render_javascript_catalog(catalog, plural)
         else:
             catalog = JavaScriptCatalog()
+            print(packages)
+            packages = None if packages == 'django.conf' else packages
             # we are passing None as the request, as the request object is currently not used by django
             response = catalog.get(self, None, domain=domain, packages=packages)
         return force_text(response.content)
@@ -74,6 +76,7 @@ class Command(BaseCommand):
             return force_text(json.dumps(data, ensure_ascii=False))
         else:
             catalog = JSONCatalog()
+            packages = None if packages == 'django.conf' else packages
             # we are passing None as the request, as the request object is currently not used by django
             response = catalog.get(self, None, domain=domain, packages=packages)
             return force_text(response.content)

--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -57,7 +57,6 @@ class Command(BaseCommand):
             response = render_javascript_catalog(catalog, plural)
         else:
             catalog = JavaScriptCatalog()
-            print(packages)
             packages = None if packages == 'django.conf' else packages
             # we are passing None as the request, as the request object is currently not used by django
             response = catalog.get(self, None, domain=domain, packages=packages)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,9 @@ envlist =
     py27-django111,
     py34-django111,
     py35-django111,
+    py27-django20,
+    py34-django20,
+    py35-django20,
     flake8,
     coverage
 
@@ -144,6 +147,24 @@ deps =
 basepython = python3.5
 deps =
     Django>=1.11,<2
+    {[testenv]deps}
+
+[testenv:py27-django20]
+basepython = python2.7
+deps =
+    Django>=2.0,<2.1
+    {[testenv]deps}
+
+[testenv:py34-django20]
+basepython = python3.4
+deps =
+    Django>=2.0,<2.1
+    {[testenv]deps}
+
+[testenv:py35-django20]
+basepython = python3.5
+deps =
+    Django>=2.0,<2.1
     {[testenv]deps}
 
 ; [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py27-django18,
-    py32-django18,
     py33-django18,
     py34-django18,
     py35-django18,
@@ -35,12 +34,6 @@ deps =
     Django>=1.8,<1.9
     {[testenv]deps}
 
-[testenv:py32-django18]
-basepython = python3.2
-deps =
-    Django>=1.8,<1.9
-    {[testenv]deps}
-
 [testenv:py33-django18]
 basepython = python3.3
 deps =
@@ -61,12 +54,6 @@ deps =
 
 [testenv:py27-django19]
 basepython = python2.7
-deps =
-    Django>=1.9,<1.10
-    {[testenv]deps}
-
-[testenv:py32-django19]
-basepython = python3.2
 deps =
     Django>=1.9,<1.10
     {[testenv]deps}
@@ -95,12 +82,6 @@ deps =
     Django>=1.10,<1.11
     {[testenv]deps}
 
-[testenv:py32-django110]
-basepython = python3.2
-deps =
-    Django>=1.10,<1.11
-    {[testenv]deps}
-
 [testenv:py33-django110]
 basepython = python3.3
 deps =
@@ -121,12 +102,6 @@ deps =
 
 [testenv:py27-django111]
 basepython = python2.7
-deps =
-    Django>=1.11,<2
-    {[testenv]deps}
-
-[testenv:py32-django111]
-basepython = python3.2
 deps =
     Django>=1.11,<2
     {[testenv]deps}


### PR DESCRIPTION
This PR adds Django 2.0 support. 
For Django 2.0 I am using the CBVs for the Javascript and JSONCatalog without giving a request object. 
This amounts to calling the following code
https://github.com/django/django/blob/master/django/views/i18n.py#L219
Additionally I added Django2.0 to the test matrix.

I was running into some problems because of the rather old version of virtualenv, I thus remove python3.2 from the tests and switched to an up-to-date version of virtualenv for running the tests. If you feel that python3.2 testing is still needed please feel free to revert the corresponding commit.
  