### PR TITLE
Use ASCII character instead of UTF-8 one to fix build with Python 3.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Installation
 
 4. Add the ``django.core.context_processors.i18n`` context processor to the
    ``context_processors`` section for your backend in the ``TEMPLATES`` setting
-   — it should have already been set by Django::
+   - it should have already been set by Django::
 
     TEMPLATES = [
       {


### PR DESCRIPTION
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "setup.py", line 11, in <module>
    long_description=open('README.rst').read(),
  File "/usr/local/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2400: ordinal not in range(128)
*** Error code 1

Stop.