### PR TITLE
Namespaced Javascript Catalog

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -36,6 +36,14 @@ Some commonly used options are:
 
     Defaults to ``js``.
 
+``-n NAMESPACE`` or ``--namespace=NAMESPACE``
+    The final gettext will be put with
+    window.SpecialBlock.gettext rather than the
+    window.gettext. This is useful for pluggable
+    modules which need Javascript i18n.
+
+    Defaults to ``None``.
+
 For a full list of options, refer to the ``compilejsi18n`` management command
 help by running::
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -68,3 +68,12 @@ Settings
     Use the legacy function ``statici18n.utils.legacy_filename`` to
     generate a filename with the language code derived from the
     ``django.utils.translation.trans_real import to_language``.
+
+.. attribute:: STATICI18N_NAMESPACE
+
+    :default: ``None``
+
+    Javascript identifier to use as namespace. This is useful when we want to
+    have separate translations for the global and the namespaced contexts.
+    The final gettext will be put under `window.<namespace>.gettext` rather
+    than the `window.gettext`. Useful for pluggable modules that need JS i18n.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-statici18n",
-    version="1.7.0",
+    version="1.7.1",
     author="Sebastien Fievet",
     author_email="zyegfryed@gmail.com",
     url="http://django-statici18n.readthedocs.org/",

--- a/src/statici18n/conf.py
+++ b/src/statici18n/conf.py
@@ -15,3 +15,5 @@ class StaticFilesConf(AppConf):
     OUTPUT_DIR = 'jsi18n'
     # The dotted path to the function that creates the filename
     FILENAME_FUNCTION = 'statici18n.utils.default_filename'
+    # Javascript identifier to use as namespace.
+    NAMESPACE = None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -101,6 +101,22 @@ def test_compile_with_output_format(settings, locale, output_format):
         settings.STATIC_ROOT, "jsi18n", locale, "djangojs.%s" % output_format))
 
 
+@pytest.mark.parametrize('locale', ['en'])
+@pytest.mark.parametrize('namespace', ['MyBlock'])
+def test_compile_with_namespace(settings, locale, namespace):
+    out = six.StringIO()
+    management.call_command('compilejsi18n', verbosity=1, stdout=out,
+                            locale=locale, outputformat='js', namespace=namespace)
+    out.seek(0)
+    lines = [l.strip() for l in out.readlines()]
+    assert len(lines) == 1
+    assert lines[0] == "processing language %s" % to_locale(locale)
+    file_path = os.path.join(settings.STATIC_ROOT, "jsi18n", locale, "djangojs.js")
+    assert os.path.exists(file_path)
+    generated_content = open(file_path).read()
+    assert 'global.MyBlock = MyBlock;' in generated_content
+
+
 @pytest.mark.usefixtures("cleandir")
 def test_compile_locale_not_exists():
     out = six.StringIO()


### PR DESCRIPTION
This PR adds the namespace parameter to the command line, and can also be read from the STATICI18N_NAMESPACE

The concept behind the change is that the javascript catalog generated by django put the gettext against window.gettext. If, however, we have a modular system in which there are many pluggable modules that require the catalog, it does not make sense to combine the entire catalog into a single catalog. This becomes especially problematic for future modules that will be created.

This PR addresses the issue such that the generated javascript catalog is modified so that the gettext is put against window.NAMESPACE.gettext. The module can use the gettext from its own NAMESPACE rather than use the global namespace of the project.

**Reviewers**
- [x] (@zyegfryed)
