### PR TITLE
Fix python3 compatibility about inlinei18n

### DIFF
--- a/src/statici18n/templatetags/statici18n.py
+++ b/src/statici18n/templatetags/statici18n.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import os
+import os, sys
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -42,4 +42,7 @@ def inlinei18n(locale):
     Behind the scenes, this is a thin wrapper around staticfiles's configred
     storage
     """
-    return mark_safe(staticfiles_storage.open(get_path(locale)).read())
+    if sys.version_info[0] = 2:
+        return mark_safe(staticfiles_storage.open(get_path(locale)).read())
+    else:
+        return mark_safe(staticfiles_storage.open(get_path(locale)).read().decode())

--- a/src/statici18n/templatetags/statici18n.py
+++ b/src/statici18n/templatetags/statici18n.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import os, sys
+import os
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -42,7 +42,4 @@ def inlinei18n(locale):
     Behind the scenes, this is a thin wrapper around staticfiles's configred
     storage
     """
-    if sys.version_info[0] = 2:
-        return mark_safe(staticfiles_storage.open(get_path(locale)).read())
-    else:
-        return mark_safe(staticfiles_storage.open(get_path(locale)).read().decode())
+    return mark_safe(staticfiles_storage.open(get_path(locale)).read().decode())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 import io
 import os
 import pytest
+import re
 
 import django
 from django.core import management
@@ -147,3 +148,4 @@ def test_inlinei18n_templatetag(locale):
     rendered = template.render(Context({'LANGUAGE_CODE': to_locale(locale)})).strip()
     assert 'var django = globals.django || (globals.django = {});' in rendered
     assert '&quot;' not in rendered
+    assert re.match('^<script>(r|b)\'',rendered) == None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -148,4 +148,4 @@ def test_inlinei18n_templatetag(locale):
     rendered = template.render(Context({'LANGUAGE_CODE': to_locale(locale)})).strip()
     assert 'var django = globals.django || (globals.django = {});' in rendered
     assert '&quot;' not in rendered
-    assert re.match('^<script>(r|b)\'',rendered) == None
+    assert re.match('^<script>(r|b)\'', rendered) is None


### PR DESCRIPTION
In Python 3, the generated js would have a `b'` prefix and `'` suffix, which make the part of javascript completely unusable. It seems to be connected to the shift to unicode of Python 3. Adding a `.decode()` fix the problem.