### PR TITLE
Change force_text to force_str

### DIFF
--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -7,7 +7,7 @@ import json
 import django
 from django.core.management.base import BaseCommand
 from django.utils.translation import to_locale, activate
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from statici18n.conf import settings
 from statici18n.utils import get_filename, get_packages
@@ -80,7 +80,7 @@ class Command(BaseCommand):
             # we are passing None as the request, as the request object is
             # currently not used by django
             response = catalog.get(self, None, domain=domain, packages=packages)
-        return force_text(response.content)
+        return force_str(response.content)
 
     def _create_json_catalog(self, locale, domain, packages):
         activate(locale)
@@ -92,14 +92,14 @@ class Command(BaseCommand):
                 'plural': plural,
             }
 
-            return force_text(json.dumps(data, ensure_ascii=False))
+            return force_str(json.dumps(data, ensure_ascii=False))
         else:
             catalog = JSONCatalog()
             packages = get_packages(packages)
             # we are passing None as the request, as the request object is
             # currently not used by django
             response = catalog.get(self, None, domain=domain, packages=packages)
-            return force_text(response.content)
+            return force_str(response.content)
 
     def _create_output(self, outputdir, outputformat, locale, domain, packages,
                        namespace):


### PR DESCRIPTION
`force_text` was [deprecated in Django 3.0](https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text) and will be removed in Django 4.0

`force_str` is supposed to be an alias of `force_text` for Python 3 (and has been documented as such since Django 1.8 as far as I can tell), so this change shouldn't be any problem for anyone. 

This will present a different behaviour if anyone's running Python 2 and tries to install the latest version of this package. But as Django 1.11 (last version to support Python 2.7) isn't supported by the Django project since April this year releasing a new version of this very stable package that doesn't support Python 2 should be fine IMO.