### PR TITLE
Update requires_system_checks for django 4.1

### DIFF
--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -13,7 +13,7 @@ from django.views.i18n import JavaScriptCatalog, JSONCatalog
 
 class Command(BaseCommand):
     help = "Collect Javascript catalog files in a single location."
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
Using boolean values for [requires_system_checks](https://docs.djangoproject.com/en/4.1/howto/custom-management-commands/#django.core.management.BaseCommand.requires_system_checks) has been deprecated since django 3.2. I changed it to an empty list, although it might be more sensible to actually check something?! I don't know enough about the [system check framework](https://docs.djangoproject.com/en/4.1/topics/checks/).