### PR TITLE
Save the timestamp of the last file compile

### DIFF
--- a/src/statici18n/management/commands/compilejsi18n.py
+++ b/src/statici18n/management/commands/compilejsi18n.py
@@ -145,6 +145,9 @@ class Command(BaseCommand):
                 settings.STATICI18N_ROOT, settings.STATICI18N_OUTPUT_DIR
             )
 
+        if not os.path.isdir(outputdir):
+            os.makedirs(outputdir)
+
         with open(os.path.join(outputdir, 'generated_at.json'), 'w') as file:
             json.dump({'generated_at': int(time())}, file)
 


### PR DESCRIPTION
This solves the following problem: 

I want the end-user to cache the complied translations file (via `Cache-Control` response header). But I need the filename to contain revision (content hash or timestamp) to have user's browser download the updated file after release.

This allows me to override `STATICI18N_FILENAME_FUNCTION` setting in my project and use the timestamp of the file generation as part of filename.

I think this entire feature of adding timestamp in the generated filename could be built-in in the library, but for now I'm sending this minimal change. What do you think?

The neat part is that in my project I can still have the i18n file regenerated "on the fly" during development by adding this to my `urls.py`:

```
if settings.DEBUG:
    # make i18n dynamically refreshed during development by serving from Django, rather than collected static files
    urlpatterns += (
        path(
            "static/jsi18n/<slug:lang_code_ignored>/djangojs.<int:timestamp_ignored>.js",
            JavaScriptCatalog.as_view(),
            name="javascript-catalog",
        ),
    )
```