### PR TITLE
Add support for Django 6.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Supported Django Versions
 
 ``django-statici18n`` works with all the Django versions officially
 supported by the Django project. At this time of writing, these are the
-4.2 (LTS), 5.2 (LTS) and 6.0 series.
+4.2 (LTS), 5.2 (LTS), 6.0 and 6.1 series.
 
 Installation
 ------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+* Add support for Django 6.1
+
 v2.7.1 (2026 Mar 15)
 --------------------
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "Django>=4.2,<6.1",
+        "Django>=4.2,<6.2",
         "django-appconf>=1.0",
     ],
     license="BSD",
@@ -25,6 +25,7 @@ setup(
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.2",
         "Framework :: Django :: 6.0",
+        "Framework :: Django :: 6.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{38,39,310,311,312}-django42,
     py{310,311,312,313,314}-django52,
     py{312,313,314}-django60,
+    py{312,313,314}-django61,
     coverage
 
 [gh-actions]
@@ -28,13 +29,14 @@ deps =
     django42: Django>=4.2,<4.3
     django52: Django>=5.2,<6
     django60: Django>=6.0,<6.1
+    django61: Django>=6.1,<6.2
 
 [testenv:coverage]
 basepython = python3.12
 commands =
     pytest -q --cov=statici18n --cov-report=xml tests
 deps =
-    Django>=4.2,<6.1
+    Django>=4.2,<6.2
     pytest
     pytest-cov
     pytest-django


### PR DESCRIPTION
Django 6.1 was recently [released](https://www.djangoproject.com/weblog/2026/aug/05/django-61-released/). This PR adds support for it.